### PR TITLE
Adjusted wrapCallback to not fail if no content-type returned (e.g. errors)

### DIFF
--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -173,7 +173,7 @@ export default class ApiClient {
     wrapCallback(httpMethod, callback = () => null) {
         return (err, res) => {
             const expectedContentType = (this.isEncrypted) ? "application/jose+json" : "application/json";
-            const invalidContentType = res && res.header && res.status !== 204 && res.header["content-type"].indexOf(expectedContentType) === -1;
+            const invalidContentType = res && res.header && res.header["content-type"] && res.header["content-type"].indexOf(expectedContentType) === -1;
             if (invalidContentType) {
                 callback([{
                     message: "Invalid Content-Type specified in Response Header",

--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -174,7 +174,7 @@ export default class ApiClient {
         return (err, res) => {
             const expectedContentType = (this.isEncrypted) ? "application/jose+json" : "application/json";
             const invalidContentType = res && res.header && res.header["content-type"] && res.header["content-type"].indexOf(expectedContentType) === -1;
-            if (invalidContentType) {
+            if (!err && invalidContentType) {
                 callback([{
                     message: "Invalid Content-Type specified in Response Header",
                 }], res ? res.body : undefined, res);

--- a/test/utils/ApiClient.spec.js
+++ b/test/utils/ApiClient.spec.js
@@ -1168,5 +1168,30 @@ describe("utils/ApiClient", () => {
             });
             callback(undefined, rawRes);
         });
+
+        it("should call callback with COMMUNICATION_ERROR if status is 429", (cb) => {
+            const client = new ApiClient("test-username", "test-password", "test-server");
+
+            const rawRes = {
+                body: "test",
+                status: 429,
+                header: {},
+            };
+
+            const rawErr = {
+                status: 429,
+            };
+
+            const callback = client.wrapCallback("POST", (err, body, res) => {
+                body.should.be.equal("test");
+                rawRes.should.be.deep.equal(res);
+                err.should.be.deep.equal([{
+                    message: "Could not communicate with test-server",
+                    code: "COMMUNICATION_ERROR",
+                }]);
+                cb();
+            });
+            callback(rawErr, rawRes);
+        });
     });
 });


### PR DESCRIPTION
Fixes https://github.com/hyperwallet/node-sdk/issues/24