### PR TITLE
DTRUNEONE-4583 Updating Error Handling V3

### DIFF
--- a/src/utils/ApiClient.js
+++ b/src/utils/ApiClient.js
@@ -140,7 +140,7 @@ export default class ApiClient {
                 .query(params)
                 .send(requestData)
                 .end(this.wrapCallback("POST", callback));
-        }).catch(() => callback("Failed to encrypt body for POST request", undefined, undefined));
+        }).catch(() => callback([{ message: "Failed to encrypt body for POST request" }], undefined, undefined));
     }
 
     /**
@@ -182,7 +182,7 @@ export default class ApiClient {
                 }
             });
             req.end(this.wrapCallback("PUT", callback));
-        }).catch((err) => callback(err, undefined, undefined)).then((err, body, res) => callback(err, body, res));
+        }).catch((err) => callback(err, undefined, undefined));
     }
 
     /**
@@ -216,7 +216,7 @@ export default class ApiClient {
                 .query(params)
                 .send(requestData)
                 .end(this.wrapCallback("PUT", callback));
-        }).catch(() => callback("Failed to encrypt body for PUT request", undefined, undefined));
+        }).catch(() => callback([{ message: "Failed to encrypt body for PUT request" }], undefined, undefined));
     }
 
     /**
@@ -258,15 +258,18 @@ export default class ApiClient {
      */
     wrapCallback(httpMethod, callback = () => null) {
         return (err, res) => {
-            const expectedContentType = (this.isEncrypted) ? "application/jose+json" : "application/json";
-            const invalidContentType = res && res.header && res.status !== 204 && res.header["content-type"].indexOf(expectedContentType) === -1;
-            if (invalidContentType) {
-                callback([{
-                    message: "Invalid Content-Type specified in Response Header",
-                }], res ? res.body : undefined, res);
-                return;
+            const contentTypeHeader = res && res.header ? res.header["content-type"] : undefined;
+            if (!err) {
+                const expectedContentType = (this.isEncrypted) ? "application/jose+json" : "application/json";
+                if (res && res.status !== 204 && contentTypeHeader && !contentTypeHeader.includes(expectedContentType)) {
+                    callback([{
+                        message: "Invalid Content-Type specified in Response Header",
+                    }], res ? res.body : undefined, res);
+                    return;
+                }
             }
-            if (this.isEncrypted) {
+            if (this.isEncrypted && contentTypeHeader && contentTypeHeader.includes("application/jose+json")
+              && res.body && this.isNotEmptyResponseBody(res.body)) {
                 this.processEncryptedResponse(httpMethod, err, res.body, callback);
             } else {
                 this.processNonEncryptedResponse(err, res, callback);
@@ -292,8 +295,8 @@ export default class ApiClient {
 
         let errors = [
             {
-                message: `Could not communicate with ${this.server}`,
-                code: "COMMUNICATION_ERROR",
+                message: err.status ? err.message : `Could not communicate with ${this.server}`,
+                code: err.status ? err.status.toString() : "COMMUNICATION_ERROR",
             },
         ];
         if (res && res.body && res.body.errors) {
@@ -313,9 +316,6 @@ export default class ApiClient {
      * @private
      */
     processEncryptedResponse(httpMethod, err, res, callback) {
-        if (!res) {
-            callback("Try to decrypt empty response body", undefined, undefined);
-        }
         this.encryption.decrypt(res)
             .then((decryptedData) => {
                 const responseBody = JSON.parse(decryptedData.payload.toString());
@@ -328,7 +328,7 @@ export default class ApiClient {
                     callback(undefined, formattedRes.body, decryptedData);
                 }
             })
-            .catch(() => callback(`Failed to decrypt response for ${httpMethod} request`, res, res));
+            .catch(() => callback([{ message: `Failed to decrypt response for ${httpMethod} request` }], res, res));
     }
 
     /**
@@ -346,5 +346,23 @@ export default class ApiClient {
                 callback(null, data);
             });
         };
+    }
+
+    /**
+     * Helper function to check if the response body is an empty object
+     *
+     * @private
+     */
+    isEmptyResponseBody(body) {
+        return Object.keys(body).length === 0 && Object.getPrototypeOf(body) === Object.prototype;
+    }
+
+    /**
+     * Helper function to check if the response body is not an empty object
+     *
+     * @private
+     */
+    isNotEmptyResponseBody(body) {
+        return !this.isEmptyResponseBody(body);
     }
 }

--- a/test/utils/ApiClient.spec.js
+++ b/test/utils/ApiClient.spec.js
@@ -160,6 +160,48 @@ describe("utils/ApiClient", () => {
         });
 
         /** @test {ApiClient#doPost} */
+        it("should return response if call was successful (without query parameters) and response body is empty", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .matchHeader("Content-Type", "application/json")
+                .post("/rest/v3/test", {
+                    test: "value",
+                })
+                .reply(202, null, { "Content-Type": "application/json" });
+
+            client.doPost("test", { test: "value" }, {}, (err, body, res) => {
+                expect(err).to.be.undefined();
+                body.should.be.deep.equal("");
+                res.status.should.be.equal(202);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doPost} */
+        it("should return response if call was successful (without query parameters) and response body is empty no content type", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .matchHeader("Content-Type", "application/json")
+                .post("/rest/v3/test", {
+                    test: "value",
+                })
+                .reply(202);
+
+            client.doPost("test", { test: "value" }, {}, (err, body, res) => {
+                expect(err).to.be.undefined();
+                body.should.be.deep.equal({});
+                res.status.should.be.equal(202);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doPost} */
         it("should return generic network error if no response was send by server", (cb) => {
             client.doPost("test", { test: "value" }, {}, (err, body, res) => {
                 err.should.be.deep.equal([{
@@ -194,6 +236,103 @@ describe("utils/ApiClient", () => {
                 }, { "Content-Type": "application/json" });
 
             client.doPost("test", { test: "value" }, {}, (err, body, res) => {
+                err.should.be.deep.equal([{
+                    message: "message",
+                    code: "FORBIDDEN",
+                    relatedResources: ["trm-f3d38df1-adb7-4127-9858-e72ebe682a79",
+                        "trm-601b1401-4464-4f3f-97b3-09079ee7723b"],
+                }]);
+
+                body.should.be.deep.equal({
+                    errors: [{
+                        message: "message",
+                        code: "FORBIDDEN",
+                        relatedResources: ["trm-f3d38df1-adb7-4127-9858-e72ebe682a79",
+                            "trm-601b1401-4464-4f3f-97b3-09079ee7723b"],
+                    }],
+                });
+
+                res.status.should.be.equal(404);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doPost} */
+        it("should return error message from http status if empty error response", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .matchHeader("Content-Type", "application/json")
+                .post("/rest/v3/test", {
+                    test: "value",
+                })
+                .reply(404);
+
+            client.doPost("test", { test: "value" }, {}, (err, body, res) => {
+                err.should.be.deep.equal([{
+                    message: "Not Found",
+                    code: "404",
+                }]);
+                body.should.be.deep.equal({});
+                res.status.should.be.equal(404);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doPost} */
+        it("should return error message if response in unexpected format", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .matchHeader("Content-Type", "application/json")
+                .post("/rest/v3/test", {
+                    test: "value",
+                })
+                .reply(429, "<html lang='en'><head><title>Request Rejected</title>" +
+                "</head><body>The requested URL was rejected. Please consult with your administrator.</body></html>",
+                { "Content-Type": "text/html" });
+
+            client.doPost("test", { test: "value" }, {}, (err, body, res) => {
+                err.should.be.deep.equal([{
+                    message: "Too Many Requests",
+                    code: "429",
+                }]);
+                body.should.be.deep.equal({});
+                res.status.should.be.equal(429);
+                res.text.should.have.string("Request Rejected");
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doPost} */
+        it("should return error message if client using encryption and responses in application/json", (cb) => {
+            const clientPath = path.join(__dirname, "..", "resources", "private-jwkset1");
+            const hwPath = path.join(__dirname, "..", "resources", "public-jwkset1");
+            const clientWithEncryption = new ApiClient("test-username", "test-password", "https://test-server", {
+                clientPrivateKeySetPath: clientPath,
+                hyperwalletKeySetPath: hwPath,
+            });
+
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/jose+json")
+                .matchHeader("Content-Type", "application/jose+json")
+                .post("/rest/v3/test", /.+/)
+                .reply(404, {
+                    errors: [{
+                        message: "message",
+                        code: "FORBIDDEN",
+                        relatedResources: ["trm-f3d38df1-adb7-4127-9858-e72ebe682a79",
+                            "trm-601b1401-4464-4f3f-97b3-09079ee7723b"],
+                    }],
+                }, { "Content-Type": "application/json" });
+
+            clientWithEncryption.doPost("test", { test: "value" }, {}, (err, body, res) => {
                 err.should.be.deep.equal([{
                     message: "message",
                     code: "FORBIDDEN",
@@ -295,7 +434,7 @@ describe("utils/ApiClient", () => {
         });
 
         /** @test {ApiClient#doPost} */
-        it("should return error when encrypted response body is empty", (cb) => {
+        it("should not return error when encrypted response body is empty", (cb) => {
             const clientPath = path.join(__dirname, "..", "resources", "private-jwkset1");
             const hwPath = path.join(__dirname, "..", "resources", "public-jwkset1");
             const clientWithEncryption = new ApiClient("test-username", "test-password", "https://test-server", {
@@ -320,11 +459,9 @@ describe("utils/ApiClient", () => {
                     });
 
                 clientWithEncryption.doPost("test", { message: "Test message" }, {}, (err, body, res) => {
-                    expect(body).to.be.undefined();
-
-                    expect(res).to.be.undefined();
-
-                    err.should.be.deep.equal("Try to decrypt empty response body");
+                    expect(err).to.be.undefined();
+                    body.should.be.deep.equal("");
+                    expect(res).to.not.be.undefined();
 
                     cb();
                 });
@@ -359,7 +496,9 @@ describe("utils/ApiClient", () => {
 
                     expect(res).to.be.undefined();
 
-                    err.should.be.deep.equal("Failed to encrypt body for POST request");
+                    err.should.be.deep.equal([{
+                        message: "Failed to encrypt body for POST request",
+                    }]);
 
                     cb();
                 });
@@ -496,6 +635,52 @@ describe("utils/ApiClient", () => {
         });
 
         /** @test {ApiClient#doPut} */
+        it("should return response if call was successful (without query parameters) and response body is empty", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .matchHeader("Content-Type", "application/json")
+                .put("/rest/v3/test", {
+                    test: "value",
+                })
+                .reply(202, null, { "Content-Type": "application/json" });
+
+            client.doPut("test", { test: "value" }, {}, (err, body, res) => {
+                expect(err).to.be.undefined();
+
+                body.should.be.deep.equal("");
+
+                res.status.should.be.equal(202);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doPut} */
+        it("should return response if call was successful (without query parameters) and response body is empty no content-type", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .matchHeader("Content-Type", "application/json")
+                .put("/rest/v3/test", {
+                    test: "value",
+                })
+                .reply(202);
+
+            client.doPut("test", { test: "value" }, {}, (err, body, res) => {
+                expect(err).to.be.undefined();
+
+                body.should.be.deep.equal({});
+
+                res.status.should.be.equal(202);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doPut} */
         it("should return generic network error if no response was send by server", (cb) => {
             client.doPut("test", { test: "value" }, {}, (err, body, res) => {
                 err.should.be.deep.equal([{
@@ -530,6 +715,103 @@ describe("utils/ApiClient", () => {
                 }, { "Content-Type": "application/json" });
 
             client.doPut("test", { test: "value" }, {}, (err, body, res) => {
+                err.should.be.deep.equal([{
+                    message: "message",
+                    code: "FORBIDDEN",
+                    relatedResources: ["trm-f3d38df1-adb7-4127-9858-e72ebe682a79",
+                        "trm-601b1401-4464-4f3f-97b3-09079ee7723b"],
+                }]);
+
+                body.should.be.deep.equal({
+                    errors: [{
+                        message: "message",
+                        code: "FORBIDDEN",
+                        relatedResources: ["trm-f3d38df1-adb7-4127-9858-e72ebe682a79",
+                            "trm-601b1401-4464-4f3f-97b3-09079ee7723b"],
+                    }],
+                });
+
+                res.status.should.be.equal(404);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doPut} */
+        it("should return error message from http status if empty error response", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .matchHeader("Content-Type", "application/json")
+                .put("/rest/v3/test", {
+                    test: "value",
+                })
+                .reply(400);
+
+            client.doPut("test", { test: "value" }, {}, (err, body, res) => {
+                err.should.be.deep.equal([{
+                    message: "Bad Request",
+                    code: "400",
+                }]);
+                body.should.be.deep.equal({});
+                res.status.should.be.equal(400);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doPut} */
+        it("should return error message if responses in unexpected format", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .matchHeader("Content-Type", "application/json")
+                .put("/rest/v3/test", {
+                    test: "value",
+                })
+                .reply(429, "<html lang='en'><head><title>Request Rejected</title>" +
+                "</head><body>The requested URL was rejected. Please consult with your administrator.</body></html>",
+                { "Content-Type": "text/html" });
+
+            client.doPut("test", { test: "value" }, {}, (err, body, res) => {
+                err.should.be.deep.equal([{
+                    message: "Too Many Requests",
+                    code: "429",
+                }]);
+                body.should.be.deep.equal({});
+                res.status.should.be.equal(429);
+                res.text.should.have.string("Request Rejected");
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doPut} */
+        it("should return error message if client using encryption and responses in application/json", (cb) => {
+            const clientPath = path.join(__dirname, "..", "resources", "private-jwkset1");
+            const hwPath = path.join(__dirname, "..", "resources", "public-jwkset1");
+            const clientWithEncryption = new ApiClient("test-username", "test-password", "https://test-server", {
+                clientPrivateKeySetPath: clientPath,
+                hyperwalletKeySetPath: hwPath,
+            });
+
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/jose+json")
+                .matchHeader("Content-Type", "application/jose+json")
+                .put("/rest/v3/test", /.+/)
+                .reply(404, {
+                    errors: [{
+                        message: "message",
+                        code: "FORBIDDEN",
+                        relatedResources: ["trm-f3d38df1-adb7-4127-9858-e72ebe682a79",
+                            "trm-601b1401-4464-4f3f-97b3-09079ee7723b"],
+                    }],
+                }, { "Content-Type": "application/json" });
+
+            clientWithEncryption.doPut("test", { test: "value" }, {}, (err, body, res) => {
                 err.should.be.deep.equal([{
                     message: "message",
                     code: "FORBIDDEN",
@@ -629,6 +911,37 @@ describe("utils/ApiClient", () => {
         });
 
         /** @test {ApiClient#doPut} */
+        it("should not return error response if encrypted PUT call was successful and response body is empty", (cb) => {
+            const clientPath = path.join(__dirname, "..", "resources", "private-jwkset1");
+            const hwPath = path.join(__dirname, "..", "resources", "public-jwkset1");
+            const clientWithEncryption = new ApiClient("test-username", "test-password", "https://test-server", {
+                clientPrivateKeySetPath: clientPath,
+                hyperwalletKeySetPath: hwPath,
+            });
+
+            nock("https://test-server")
+                .filteringPath(() => "/")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/jose+json")
+                .matchHeader("Content-Type", "application/jose+json")
+                .put("/", /.+/)
+                .reply(201, null, {
+                    "Content-Type": "application/jose+json;",
+                });
+
+            clientWithEncryption.doPut("test", { message: "Test message" }, {}, (err, body, res) => {
+                expect(err).to.be.undefined();
+
+                expect(res).to.not.be.undefined();
+
+                body.should.be.deep.equal("");
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doPut} */
         it("should return error when fail to encrypt PUT request body", (cb) => {
             const clientPath = path.join(__dirname, "..", "resources", "private-jwkset1");
             const hwPath = path.join(__dirname, "..", "resources", "public-jwkset1");
@@ -656,7 +969,9 @@ describe("utils/ApiClient", () => {
 
                     expect(res).to.be.undefined();
 
-                    err.should.be.deep.equal("Failed to encrypt body for PUT request");
+                    err.should.be.deep.equal([{
+                        message: "Failed to encrypt body for PUT request",
+                    }]);
 
                     cb();
                 });
@@ -687,7 +1002,9 @@ describe("utils/ApiClient", () => {
                     .reply(201, encryptedBody, { "Content-Type": "application/jose+json" });
 
                 clientWithEncryption.doPut("test", { message: "Test message" }, {}, (err, body, res) => {
-                    err.should.be.deep.equal("Failed to decrypt response for PUT request");
+                    err.should.be.deep.equal([{
+                        message: "Failed to decrypt response for PUT request",
+                    }]);
 
                     expect(body).to.not.be.undefined();
 
@@ -791,18 +1108,26 @@ describe("utils/ApiClient", () => {
                 .matchHeader("Authorization", authHeader)
                 .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
                 .matchHeader("Accept", "application/json")
-                .matchHeader("Content-Type", "multipart/form-data")
-                .put("/rest/v3/test", { test: "value" })
-                .reply(400, []
-                    , { "Content-Type": "application/jose+json" });
+                .put("/rest/v3/testmultipart", /.+/)
+                .reply(400, {
+                    errors: [{
+                        message: "message",
+                        code: "FORBIDDEN",
+                    }],
+                }, { "Content-Type": "application/json" });
 
-            client.doPutMultipart("test", data, (err, body, res) => {
+            client.doPutMultipart("testmultipart", data, (err, body, res) => {
                 err.should.be.deep.equal([{
-                    message: "Could not communicate with https://test-server",
-                    code: "COMMUNICATION_ERROR",
+                    message: "message",
+                    code: "FORBIDDEN",
                 }]);
-                expect(body).to.be.undefined();
-                expect(res).to.be.undefined();
+                body.should.be.deep.equal({
+                    errors: [{
+                        message: "message",
+                        code: "FORBIDDEN",
+                    }],
+                });
+                res.status.should.be.equal(400);
 
                 cb();
             });
@@ -897,6 +1222,46 @@ describe("utils/ApiClient", () => {
                 });
 
                 res.status.should.be.equal(200);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doGet} */
+        it("should return response if call was successful (with query parameters) and response body is empty", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .get("/rest/v3/test")
+                .query({ sort: "test" })
+                .reply(202, null, {
+                    "Content-Type": "application/json",
+                });
+
+            client.doGet("test", { sort: "test" }, (err, body, res) => {
+                expect(err).to.be.undefined();
+                body.should.be.deep.equal("");
+                res.status.should.be.equal(202);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doGet} */
+        it("should return response if call was successful (with query parameters) and response body is empty no content-type", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .get("/rest/v3/test")
+                .query({ sort: "test" })
+                .reply(202);
+
+            client.doGet("test", { sort: "test" }, (err, body, res) => {
+                expect(err).to.be.undefined();
+                body.should.be.deep.equal({});
+                res.status.should.be.equal(202);
 
                 cb();
             });
@@ -1029,6 +1394,96 @@ describe("utils/ApiClient", () => {
         });
 
         /** @test {ApiClient#doGet} */
+        it("should return error message from http status if empty error response", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .get("/rest/v3/test")
+                .reply(500);
+
+            client.doGet("test", {}, (err, body, res) => {
+                err.should.be.deep.equal([{
+                    message: "Internal Server Error",
+                    code: "500",
+                }]);
+                body.should.be.deep.equal({});
+                res.status.should.be.equal(500);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doGet} */
+        it("should return error message if responses in unexpected format", (cb) => {
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/json")
+                .get("/rest/v3/test")
+                .reply(429, "<html lang='en'><head><title>Request Rejected</title>" +
+                "</head><body>The requested URL was rejected. Please consult with your administrator.</body></html>",
+                { "Content-Type": "text/html" });
+
+            client.doGet("test", {}, (err, body, res) => {
+                err.should.be.deep.equal([{
+                    message: "Too Many Requests",
+                    code: "429",
+                }]);
+                body.should.be.deep.equal({});
+                res.status.should.be.equal(429);
+                res.text.should.have.string("Request Rejected");
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doGet} */
+        it("should return error message if client using encryption and responses in application/json", (cb) => {
+            const clientPath = path.join(__dirname, "..", "resources", "private-jwkset1");
+            const hwPath = path.join(__dirname, "..", "resources", "public-jwkset1");
+            const clientWithEncryption = new ApiClient("test-username", "test-password", "https://test-server", {
+                clientPrivateKeySetPath: clientPath,
+                hyperwalletKeySetPath: hwPath,
+            });
+
+            nock("https://test-server")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/jose+json")
+                .get("/rest/v3/test")
+                .reply(404, {
+                    errors: [{
+                        message: "message",
+                        code: "FORBIDDEN",
+                        relatedResources: ["trm-f3d38df1-adb7-4127-9858-e72ebe682a79",
+                            "trm-601b1401-4464-4f3f-97b3-09079ee7723b"],
+                    }],
+                }, { "Content-Type": "application/json" });
+
+            clientWithEncryption.doGet("test", {}, (err, body, res) => {
+                err.should.be.deep.equal([{
+                    message: "message",
+                    code: "FORBIDDEN",
+                    relatedResources: ["trm-f3d38df1-adb7-4127-9858-e72ebe682a79",
+                        "trm-601b1401-4464-4f3f-97b3-09079ee7723b"],
+                }]);
+
+                body.should.be.deep.equal({
+                    errors: [{
+                        message: "message",
+                        code: "FORBIDDEN",
+                        relatedResources: ["trm-f3d38df1-adb7-4127-9858-e72ebe682a79",
+                            "trm-601b1401-4464-4f3f-97b3-09079ee7723b"],
+                    }],
+                });
+
+                res.status.should.be.equal(404);
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doGet} */
         it("should return encrypted response if encrypted GET call was successful (without query parameters)", (cb) => {
             const clientPath = path.join(__dirname, "..", "resources", "private-jwkset1");
             const hwPath = path.join(__dirname, "..", "resources", "public-jwkset1");
@@ -1101,7 +1556,62 @@ describe("utils/ApiClient", () => {
                 });
             });
         });
+
+        /** @test {ApiClient#doGet} */
+        it("should return response if call was successful (with query parameters and encryption) and response body is empty", (cb) => {
+            const clientPath = path.join(__dirname, "..", "resources", "private-jwkset1");
+            const hwPath = path.join(__dirname, "..", "resources", "public-jwkset1");
+            const clientWithEncryption = new ApiClient("test-username", "test-password", "https://test-server", {
+                clientPrivateKeySetPath: clientPath,
+                hyperwalletKeySetPath: hwPath,
+            });
+
+            nock("https://test-server")
+                .filteringPath(() => "/")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/jose+json")
+                .get("/")
+                .reply(202, null, {
+                    "Content-Type": "application/jose+json",
+                });
+
+            clientWithEncryption.doGet("test", {}, (err, body, res) => {
+                expect(err).to.be.undefined();
+                expect(res).to.not.be.undefined();
+                body.should.be.deep.equal("");
+
+                cb();
+            });
+        });
+
+        /** @test {ApiClient#doGet} */
+        it("should return response if call was successful (with query parameters and encryption) and response body is empty no content-type", (cb) => {
+            const clientPath = path.join(__dirname, "..", "resources", "private-jwkset1");
+            const hwPath = path.join(__dirname, "..", "resources", "public-jwkset1");
+            const clientWithEncryption = new ApiClient("test-username", "test-password", "https://test-server", {
+                clientPrivateKeySetPath: clientPath,
+                hyperwalletKeySetPath: hwPath,
+            });
+
+            nock("https://test-server")
+                .filteringPath(() => "/")
+                .matchHeader("Authorization", authHeader)
+                .matchHeader("User-Agent", `Hyperwallet Node SDK v${packageJson.version}`)
+                .matchHeader("Accept", "application/jose+json")
+                .get("/")
+                .reply(202);
+
+            clientWithEncryption.doGet("test", {}, (err, body, res) => {
+                expect(err).to.be.undefined();
+                expect(res).to.not.be.undefined();
+                body.should.be.deep.equal({});
+
+                cb();
+            });
+        });
     });
+
 
     describe("wrapCallback()", () => {
         it("should return a 'function' without a argument", () => {
@@ -1127,7 +1637,9 @@ describe("utils/ApiClient", () => {
             const rawRes = {
                 body: "test",
                 status: 200,
-                type: "application/json",
+                header: {
+                    "content-type": "application/json",
+                },
             };
 
             const callback = client.wrapCallback("POST", (err, body, res) => {
@@ -1154,7 +1666,9 @@ describe("utils/ApiClient", () => {
                     }],
                 },
                 status: 404,
-                type: "application/json",
+                header: {
+                    "content-type": "application/json",
+                },
             };
 
             const callback = client.wrapCallback("POST", (err, body, res) => {
@@ -1185,7 +1699,9 @@ describe("utils/ApiClient", () => {
             const rawRes = {
                 body: "test",
                 status: 404,
-                type: "application/json",
+                header: {
+                    "content-type": "application/json",
+                },
             };
 
             const callback = client.wrapCallback("POST", (err, body, res) => {
@@ -1225,7 +1741,9 @@ describe("utils/ApiClient", () => {
                 const rawRes = {
                     body: encryptedBody,
                     status: 200,
-                    type: "application/jose+json",
+                    header: {
+                        "content-type": "application/jose+json",
+                    },
                 };
                 callback(undefined, rawRes);
             });
@@ -1251,7 +1769,7 @@ describe("utils/ApiClient", () => {
 
                 cb();
             });
-            callback(new Error(), rawRes);
+            callback(undefined, rawRes);
         });
 
         it("should call callback with no errors if Content-type is missing and response is noContent", (cb) => {


### PR DESCRIPTION
**Changes in this Pull Request:**

Updating error handling to support the following
- Hyperwallet error messages - Content-Type - application/json
- Hyperwallet encrypted error messages - Content-Type - application/jose+json
- Empty body
- Unexpected error messages returned by the server

Wrap error messages that we get from encryption/decryption failures - http://hyperwallet.github.io/node-sdk/typedef/index.html#static-typedef-api-callback
Removing unnecessary promise chain in doPutMultipart

**Testing**
- Successful Response ✅ 
- Hyperwallet Constraint Error message (application/json) ✅ 
- Hyperwallet Duplicate Error message (application/json) ✅ 
- Unexpected Response from Server (text/html) ✅ 
- Empty Error Response ✅ 
- Upload Document ✅ 
- Encrypted - Successful Response ✅ 
- Encrypted - Hyperwallet Duplicate Error message (application/json) ✅ 
- Encrypted - Hyperwallet Error response (application/jose+json) ✅ 
- Encrypted Client - Unexpected Response from Server (text/html) ✅ 
- Encrypted Client - Empty Error Response ✅ 

**Unit Tests**
```
  438 passing (5s)
  2 pending
```