### PR TITLE
upgraded node-jose and gh-pages versions.

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "dependencies": {
     "form-data": "^3.0.0",
-    "node-jose": "^2.1.0",
+    "node-jose": "^2.2.0",
     "object-assign": "^4.1.0",
     "superagent": "^4.0.0",
     "uuid": "^8.3.1"
@@ -55,7 +55,7 @@
     "eslint": "^4.19.1",
     "eslint-config-airbnb-base": "^13.2.0",
     "eslint-plugin-import": "^2.17.2",
-    "gh-pages": "^3.1.0",
+    "gh-pages": "^6.1.1",
     "mocha": "^5.2.0",
     "nock": "^10.0.4",
     "nyc": "^15.0.0",


### PR DESCRIPTION
DTSERWONE-2100
Version upgrade for node-jose and gh-pages to fix security vulnerability.